### PR TITLE
Add name to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,7 @@ maintainer_email  "gerhard@lazu.co.uk"
 license           "Apache 2.0"
 description       "A generic htpasswd implementation leveraging openssl directly"
 version           "0.2.0"
+name              "htpasswd"
 
 recipe "htpasswd", "Sets up a common htpasswd directory, uses openssl directly"
 


### PR DESCRIPTION
To be able to use it with Berkshelf 3 :

"While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry"
